### PR TITLE
Spec tests & controllers for User's CRUD actions

### DIFF
--- a/app/controllers/Api/v1/users_controller.rb
+++ b/app/controllers/Api/v1/users_controller.rb
@@ -1,20 +1,56 @@
 class Api::V1::UsersController < ApplicationController
-  before_action :set_user, only: [:show]
-    
+  before_action :set_user, only: [:show, :update, :destroy]
+  
+  def index
+    @users = User.all
+
+    render json: 
+      @users.present? ? @users : { error: "Users not found" },
+      status: @users.present? ? :ok : :not_found
+  end
+
   def show
     render json: 
-      @user ? @user : { error: "User not found" }, 
+      @user ? @user : { error: "User not found" },
       status: @user ? :ok : :not_found
+  end
+
+  def new
+    @user = User.new
+    render json: { user: @user }
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      render json: { user: @user }, status: :created
+    else
+      render json: { errors: @user.errors }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @user.update(user_params)
+      render json: { user: @user }, status: :ok
+    else
+      render json: { errors: @user.errors }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy 
+    render json:
+      @user ? @user.destroy : { error: "User not found" },
+      status: @user ? :no_content : :not_found
   end
 
   private
 
   def set_user
-    @user = User.find_by(id: params[:id])
+    @user = User.includes(:expertises).find_by(id: params[:id])
   end
 
   def user_params
-    params.require(:user).permit(:email, :role, :first_name, :middle_name, :last_name, :username, :location, :company, :job_title, :bio, :guidances, :languages, :skills, :is_available, :timezone, :social_platforms, :profile_img)
+    params.require(:user).permit(:email, :role, :first_name, :middle_name, :last_name, :username, :location, :company, :job_title, :bio, :is_available, :timezone, :social_platforms, :profile_img, :password, guidances: [], languages: [], skills: [])
   end  
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,8 @@ class User < ApplicationRecord
 
   has_many :reviews
   has_many :experiences
-  has_many :expertises
+  has_many :expertises, dependent: :destroy
   has_many :projects
   belongs_to :project_area, optional: true
+
 end

--- a/spec/controllers/Api/v1/users_controller_spec.rb
+++ b/spec/controllers/Api/v1/users_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
 
       it "returns associated expertises" do
         expect(users.last.expertises).not_to be_empty
-      expect(users.last.expertises.size).to eq(3)
+        expect(users.last.expertises.size).to eq(3)
       end
     end
 
@@ -58,27 +58,27 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     let(:user_params) { attributes_for(:user) }
     let(:invalid_user_params) { attributes_for(:user).merge(email: nil) }
     
-      context "when the parameters are valid" do
-        it "creates a user" do 
-          post :create, format: :json, params: { user: user_params }
-          expect(response.status).to eq(201)
-          user_response = JSON.parse(response.body)["user"]
-          expect(user_response["first_name"]).to eq(user_params[:first_name])
-          expect(user_response["location"]).to eq(user_params[:location])
-          expect(user_response["guidances"]).to eq(user_params[:guidances])
-        end
-      end
-
-      context "when the parameters are not valid" do
-        it "does not create a user" do 
-          post :create, format: :json, params: { user: invalid_user_params }
-          expect(response.status).to eq(422)
-          error_response = JSON.parse(response.body)["errors"]
-          expect(error_response["email"]).to include("can't be blank")
-        end
+    context "when the parameters are valid" do
+      it "creates a user" do 
+        post :create, format: :json, params: { user: user_params }
+        expect(response.status).to eq(201)
+        user_response = JSON.parse(response.body)["user"]
+        expect(user_response["first_name"]).to eq(user_params[:first_name])
+        expect(user_response["location"]).to eq(user_params[:location])
+        expect(user_response["guidances"]).to eq(user_params[:guidances])
       end
     end
 
+    context "when the parameters are not valid" do
+      it "does not create a user" do 
+        post :create, format: :json, params: { user: invalid_user_params }
+        expect(response.status).to eq(422)
+        error_response = JSON.parse(response.body)["errors"]
+        expect(error_response["email"]).to include("can't be blank")
+      end
+    end
+  end
+  
   describe "PUT /users/:id" do
     let(:user_params) { attributes_for(:user).merge(email: "testing@gmail.com") }
     let(:invalid_user_params) { attributes_for(:user).merge(email: nil) }

--- a/spec/controllers/Api/v1/users_controller_spec.rb
+++ b/spec/controllers/Api/v1/users_controller_spec.rb
@@ -1,24 +1,122 @@
-module Api
-  module V1
-    describe UsersController, type: :controller do
-      context "#show" do
-        it "returns a specifc user" do
-          user = FactoryBot.create(:user)
-          get :show, format: :json, params: { id: user.id }
-          expect(response.status).to eq(200)
-          user_response = JSON.parse(response.body)
-          expect(user_response["first_name"]).to eq(user.first_name)
-          expect(user_response["location"]).to eq(user.location)
-          expect(user_response["guidances"]).to eq(user.guidances)
-        end
+RSpec.describe Api::V1::UsersController, type: :controller do
+  let(:users) { create_list(:user, 10) }
+  let(:user_id) { users.last.id }
+  let(:expertises) { create_list(:expertise, 3, user_id: user_id) }
+  
+  describe "GET /users" do
+    context "when users exist" do
+      before { users }
+      it "returns a list of users" do
+        get :index, format: :json
+        expect(response.status).to eq(200)
+        users_response = JSON.parse(response.body)
+        expect(users_response).not_to be_empty
+        expect(users_response.size).to eq(10)
+      end
+    end
+    
+    context "when users do not exist" do
+      let(:users) { [] }
+      it "returns an empty array with a 404" do
+        get :index, format: :json
+        expect(response.status).to eq(404)
+        error_response = JSON.parse(response.body)
+        expect(error_response["error"]).to eq("Users not found")
+      end
+    end
+  end
+  
+  describe "GET /users/:id" do
+    context "when a user exists" do
+      before { expertises }
+      it "returns a specific user" do     
+        get :show, format: :json, params: { id: user_id }
+        expect(response.status).to eq(200)
+        user_response = JSON.parse(response.body)
+        expect(user_response["first_name"]).to eq(users.last.first_name)
+        expect(user_response["location"]).to eq(users.last.location)
+        expect(user_response["guidances"]).to eq(users.last.guidances)
+      end
 
-        it "returns a 404 for missing user" do
-          get :show, format: :json, params: { id: 0 }
-          expect(response.status).to eq(404)
-          error_response = JSON.parse(response.body)
-          expect(error_response["error"]).to eq("User not found")
+      it "returns associated expertises" do
+        expect(users.last.expertises).not_to be_empty
+      expect(users.last.expertises.size).to eq(3)
+      end
+    end
+
+    context "when a user does not exist" do
+      it "returns a 404 for missing user" do
+        get :show, format: :json, params: { id: 0 }
+        expect(response.status).to eq(404)
+        error_response = JSON.parse(response.body)
+        expect(error_response["error"]).to eq("User not found")
+      end
+    end
+  end 
+
+  describe "POST /users" do 
+    let(:user_params) { attributes_for(:user) }
+    let(:invalid_user_params) { attributes_for(:user).merge(email: nil) }
+    
+      context "when the parameters are valid" do
+        it "creates a user" do 
+          post :create, format: :json, params: { user: user_params }
+          expect(response.status).to eq(201)
+          user_response = JSON.parse(response.body)["user"]
+          expect(user_response["first_name"]).to eq(user_params[:first_name])
+          expect(user_response["location"]).to eq(user_params[:location])
+          expect(user_response["guidances"]).to eq(user_params[:guidances])
         end
-      end 
+      end
+
+      context "when the parameters are not valid" do
+        it "does not create a user" do 
+          post :create, format: :json, params: { user: invalid_user_params }
+          expect(response.status).to eq(422)
+          error_response = JSON.parse(response.body)["errors"]
+          expect(error_response["email"]).to include("can't be blank")
+        end
+      end
+    end
+
+  describe "PUT /users/:id" do
+    let(:user_params) { attributes_for(:user).merge(email: "testing@gmail.com") }
+    let(:invalid_user_params) { attributes_for(:user).merge(email: nil) }
+
+    context "when updating an existing user with valid parameters" do 
+      it "updates the record of a user" do
+        put :update, format: :json, params: { id: user_id, user: user_params }
+        expect(response.status).to eq(200)
+        updated_response = JSON.parse(response.body)["user"]
+        expect(updated_response["email"]).to eq("testing@gmail.com")
+      end
+    end
+
+    context "when updating an existing user with invalid parameters" do 
+      it "does not update the record of a user" do
+        put :update, format: :json, params: { id: user_id, user: invalid_user_params }
+        expect(response.status).to eq(422)
+        error_response = JSON.parse(response.body)["errors"]
+        expect(error_response["email"]).to include("can't be blank")
+      end
+    end
+  end 
+
+  describe "DESTROY /users/:id" do
+    context "when the specific user exists" do
+      it "deletes a user" do
+        delete :destroy, format: :json, params: { id: user_id }
+        expect(response.status).to eq(204)
+        expect(User.exists?(user_id)).to be_falsey
+        expect(Expertise.where(user_id: user_id)).to be_empty
+      end
+    end
+
+    context "when the specifc user does not exist" do
+      it "returns a 404 for missing user" do
+        delete :destroy, format: :json, params: { id: 0 }
+        expect(response.status).to eq(404)
+      end
     end
   end
 end


### PR DESCRIPTION
In addition to the present User#Show, the spec tests and controllers for INDEX, CREATE, UPDATE and DESTROY actions have been included accordingly

User#Show also has been further updated to retrieve all the User's associated expertises by adding eager loading in the set_user method. In such case, FE doesn't need to make a separate request and when it fetches the specific user, the associated expertise data in a single query will be retrieved at once