### PR TITLE
Code Owners setup

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# This file controls who is tagged for review for any given pull request.
+
+# These owners will be the default initial owners for everything in the repo.
+
+* @Roveri91 @srollins01 @ayau8
+
+


### PR DESCRIPTION
Code Owners has been setup with Simone, Sarah and I being the initial owners for review for all files and directories in the repo. This can be updated as we have a clearer picture in terms of work split

As implementing a sequential review process within Code Owners isn't feasible, after review by one of the initial owners, we can either 1) manually request reviews from Matt or Paulo or 2) set up GitHub Action to automate the process

For additional protection, "require review from Code Owners" has been updated accordingly in branch protection rule

<img width="462" alt="Screenshot 2024-03-15 at 3 24 58 PM" src="https://github.com/ayau8/menternshift-backend/assets/136456061/c2b21cc5-e147-43ff-a51b-c30b860288a6">

Reference: https://docs.gitlab.com/ee/user/project/codeowners/#codeowners-file




